### PR TITLE
Ignore rawBytes in StringBodyDTO

### DIFF
--- a/core/src/main/java/software/xdev/mockserver/serialization/model/StringBodyDTO.java
+++ b/core/src/main/java/software/xdev/mockserver/serialization/model/StringBodyDTO.java
@@ -18,6 +18,8 @@ package software.xdev.mockserver.serialization.model;
 import java.util.Arrays;
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import software.xdev.mockserver.model.StringBody;
 
 
@@ -50,6 +52,7 @@ public class StringBodyDTO extends BodyWithContentTypeDTO
 		return this.subString;
 	}
 	
+	@JsonIgnore
 	public byte[] getRawBytes()
 	{
 		return this.rawBytes;


### PR DESCRIPTION
The serialization of a `StringBodyDTO` looks like this:

```json
{
      "type" : "STRING",
      "string" : "{\"id\":37,\"username\":\"john.doe\"}",
      "rawBytes" : "eyJpZCI6MzcsInVzZXJuYW1lIjoiam9obi5kb2UifQ==",
      "contentType" : "application/json"
}
```

To be consistent with the `StringBody` implementation:

https://github.com/xdev-software/mockserver-neolight/blob/4fa867a9331f06e674c05dd092bc3563b8e86b4b/core/src/main/java/software/xdev/mockserver/model/StringBody.java#L100-L104

I think it would make sense to ignore the `rawBytes` attribute in the `StringBodyDTO`, to have it like this:

```json
{
      "type" : "STRING",
      "string" : "{\"id\":37,\"username\":\"john.doe\"}",
      "contentType" : "application/json"
}
```
